### PR TITLE
Feature/regenerating-twitter-client

### DIFF
--- a/solana_mint_nft.go
+++ b/solana_mint_nft.go
@@ -117,7 +117,7 @@ func requestMintToken(jsonCID string) (nftAddress string, sig string, err error)
 					MintData: tokenmeta.Data{
 						Name:                 "Movetain Tweet Token",
 						Symbol:               "MTT",
-						Uri:                  "http://" + HOST_IP + ":8080/ipfs/" + jsonCID,
+						Uri:                  "http://" + JSON_KEYS.HostIP + ":8080/ipfs/" + jsonCID,
 						SellerFeeBasisPoints: 100,
 						Creators: &[]tokenmeta.Creator{
 							{

--- a/timer.go
+++ b/timer.go
@@ -8,6 +8,7 @@ import (
 func timer(latest_replied_id string) {
 	ticker := time.NewTicker(20 * time.Second)
 	defer ticker.Stop()
+	count := 0
 	for {
 		select {
 		case <-ticker.C:
@@ -15,6 +16,13 @@ func timer(latest_replied_id string) {
 			updated_latest_replied_id := botMain(latest_replied_id)
 			// 最終返信を更新
 			latest_replied_id = updated_latest_replied_id
+			// カウント
+			count++
+			// 2時間(360x20)経ったらクライアントを再起動
+			if count == 350 {
+				TWITTER_CLIENT = regenerateTwitterClient(JSON_KEYS)
+				count = 0
+			}
 		}
 	}
 }

--- a/twitter_auth.go
+++ b/twitter_auth.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/g8rswimmer/go-twitter/v2"
 )
 
 type authorize struct {
@@ -27,7 +29,25 @@ type responseJson struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-func requestAccessToken(jsonKeys jsonKeys) (access_token string, err error) {
+func regenerateTwitterClient(jsonKeys jsonKeys) (newClient *twitter.Client) {
+	log.Println("[Twitter] Regenerating Twitter client.")
+
+	// アクセストークンを再生成
+	newToken, err := requestAccessToken(jsonKeys)
+	if err != nil {
+		log.Fatalf("[Twitter] can't get ACCESS_TOKEN: %v", err)
+	}
+
+	// クライアント再生成
+	newClient = &twitter.Client{
+		Authorizer: authorize{Token: newToken},
+		Client:     http.DefaultClient,
+		Host:       "https://api.twitter.com",
+	}
+	return
+}
+
+func requestAccessToken(jsonKeys jsonKeys) (accessToken string, err error) {
 	// secrets/refreshtokenから読み込み
 	bytes, err := ioutil.ReadFile("secrets/refreshtoken")
 	if err != nil {

--- a/twitter_auth.go
+++ b/twitter_auth.go
@@ -114,6 +114,7 @@ func requestAccessToken(jsonKeys jsonKeys) (accessToken string, err error) {
 	}
 
 	// 取得したアクセストークン
-	access_token = responseJson.AccessToken
+	accessToken = responseJson.AccessToken
+
 	return
 }

--- a/twitter_mention_timeline.go
+++ b/twitter_mention_timeline.go
@@ -46,6 +46,6 @@ func requestUserMentionTimeline() (timeline *twitter.UserMentionTimelineResponse
 		Expansions: []twitter.Expansion{twitter.ExpansionAuthorID},
 		MaxResults: 5,
 	}
-	timeline, err = TWITTER_CLIENT.UserMentionTimeline(context.Background(), BOT_USER_ID, opts)
+	timeline, err = TWITTER_CLIENT.UserMentionTimeline(context.Background(), JSON_KEYS.BotUserId, opts)
 	return
 }


### PR DESCRIPTION
2時間おきに再生成するアレ。
リフレッシュトークンを使って新しいアクセストークンを発行、それを使ってTwitterクライアントを再生成してグローバルを書き換える。issue: https://github.com/shmn7iii/movetain/issues/5